### PR TITLE
Automatic slug conference update

### DIFF
--- a/src/Controller/Admin/ConferenceCrudController.php
+++ b/src/Controller/Admin/ConferenceCrudController.php
@@ -4,7 +4,7 @@ namespace App\Controller\Admin;
 
 use App\Entity\Conference;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextEditorField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
@@ -15,14 +15,10 @@ class ConferenceCrudController extends AbstractCrudController
         return Conference::class;
     }
 
-    /*
     public function configureFields(string $pageName): iterable
     {
-        return [
-            IdField::new('id'),
-            TextField::new('title'),
-            TextEditorField::new('description'),
-        ];
+        yield TextField::new('city');
+        yield TextField::new('year');
+        yield BooleanField::new('isInternational');
     }
-    */
 }

--- a/src/Entity/Conference.php
+++ b/src/Entity/Conference.php
@@ -70,9 +70,7 @@ class Conference
 
     public function computeSlug(SluggerInterface $slugger)
     {
-        if (!$this->slug || '-' === $this->slug) {
-            $this->slug = (string) $slugger->slug((string) $this)->lower();
-        }
+        $this->slug = (string) $slugger->slug((string) $this)->lower();
     }
 
     public function getCity(): ?string


### PR DESCRIPTION
Generate the conference slug unconditionally to allow the slug to be updated when modifying the conference from the administration page. (App\Entity\Conference)
Define the editable fields for a conference on the administration page to avoid the automatic slug field. (App\Controller\Admin\ConferenceCrudController)